### PR TITLE
refactor: Overhaul and achieve parity between hosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,12 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    
+
     home-manager.url = "github:nix-community/home-manager";
-    
+
     darwin.url = "github:LnL7/nix-darwin/master";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
-    
+
     disko.url = "github:nix-community/disko";
     disko.inputs.nixpkgs.follows = "nixpkgs";
 
@@ -20,18 +20,19 @@
     homebrew-core.flake = false;
     homebrew-cask.url = "github:homebrew/homebrew-cask";
     homebrew-cask.flake = false;
-    
+
     tokyonight.url = "github:mrjones2014/tokyonight.nix";
   };
 
   outputs = { self, darwin, nix-homebrew, homebrew-bundle, homebrew-core, homebrew-cask, home-manager, nixpkgs, disko, tokyonight } @inputs:
     let
       variables = {
-        user = "bassim-nix";
         email = "bassim101@gmail.com";
+        userName = "bassim-nix";
         fullName = "Bassim Shahidy";
         hostName.nixos = "nixos";
         hostName.vm = "nixos-vm";
+        hostName.darwin = "nixos-mac";
       };
       linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
       darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
@@ -46,12 +47,14 @@
       };
       mkApp = scriptName: system: {
         type = "app";
-        program = "${(nixpkgs.legacyPackages.${system}.writeScriptBin scriptName ''
-          #!/usr/bin/env bash
-          PATH=${nixpkgs.legacyPackages.${system}.git}/bin:$PATH
-          echo "Running ${scriptName} for ${system}"
-          exec ${self}/apps/${system}/${scriptName}
-        '')}/bin/${scriptName}";
+        program = "${
+          (nixpkgs.legacyPackages.${system}.writeScriptBin scriptName ''
+            #!/usr/bin/env bash
+            PATH=${nixpkgs.legacyPackages.${system}.git}/bin:$PATH
+            echo "Running ${scriptName} for ${system}"
+            exec ${self}/apps/${system}/${scriptName}
+          '')
+        }/bin/${scriptName}";
       };
       mkLinuxApps = system: {
         "apply" = mkApp "apply" system;
@@ -73,18 +76,20 @@
     in
     {
       devShells = forAllSystems devShell;
-      apps = nixpkgs.lib.genAttrs linuxSystems mkLinuxApps // nixpkgs.lib.genAttrs darwinSystems mkDarwinApps;
+      apps = nixpkgs.lib.genAttrs linuxSystems mkLinuxApps
+        // nixpkgs.lib.genAttrs darwinSystems mkDarwinApps;
 
       darwinConfigurations = nixpkgs.lib.genAttrs darwinSystems 
         (system: darwin.lib.darwinSystem {
           inherit system;
-          specialArgs = inputs // { inherit variables; };
+          specialArgs = { inherit variables inputs; };
           modules = [
             home-manager.darwinModules.home-manager
             nix-homebrew.darwinModules.nix-homebrew
             {
+              # TODO: Move to dedicated homebrew module incl. casks
               nix-homebrew = {
-                user = variables.user;
+                user = variables.userName;
                 enable = true;
                 taps = {
                   "homebrew/homebrew-core" = homebrew-core;
@@ -98,105 +103,27 @@
             ./hosts/darwin
           ];
         }
-      );
+        );
 
-      # nixosConfigurations = {
-      #   nixos = nixpkgs.lib.nixosSystem {
-      #     system = "x86_64-linux";
-      #     specialArgs = inputs // { inherit variables; };
-      #     modules = [
-      #       disko.nixosModules.disko
-      #       home-manager.nixosModules.home-manager {
-      #         home-manager = {
-      #           extraSpecialArgs = { inherit variables; };
-      #           useGlobalPkgs = true;
-      #           useUserPackages = true;
-      #           users.${variables.user} = import ./modules/nixos/home-manager.nix;
-      #         };
-      #       }
-      #       ./hosts/nixos
-      #     ];
-      #   };
-      #
-      #   vm = nixpkgs.lib.nixosSystem {
-      #     system = "x86_64-linux";
-      #     specialArgs = inputs // { inherit variables; };
-      #     modules = [
-      #       disko.nixosModules.disko
-      #       home-manager.nixosModules.home-manager {
-      #         home-manager = {
-      #           extraSpecialArgs = { inherit variables; };
-      #           useGlobalPkgs = true;
-      #           useUserPackages = true;
-      #           users.${variables.user} = import ./modules/nixos/home-manager.nix;
-      #         };
-      #       }
-      #       ./hosts/vm
-      #     ];
-      #   };
-      # };
-
-    #   nixosConfigurations = {
-    #   nixos = nixpkgs.lib.genAttrs linuxSystems (system: nixpkgs.lib.nixosSystem {
-    #     inherit system;
-    #     specialArgs = inputs // { inherit variables; };
-    #     modules = [
-    #       disko.nixosModules.disko
-    #       home-manager.nixosModules.home-manager {
-    #         home-manager = {
-    #           extraSpecialArgs = { inherit variables; };
-    #           useGlobalPkgs = true;
-    #           useUserPackages = true;
-    #           users.${variables.user} = import ./modules/nixos/home-manager.nix;
-    #         };
-    #       }
-    #       ./hosts/nixos
-    #     ];
-    #   });
-    #
-    #   vm = nixpkgs.lib.genAttrs linuxSystems (system: nixpkgs.lib.nixosSystem {
-    #     inherit system;
-    #     specialArgs = inputs // { inherit variables; };
-    #     modules = [
-    #       disko.nixosModules.disko
-    #       home-manager.nixosModules.home-manager {
-    #         home-manager = {
-    #           extraSpecialArgs = { inherit variables; };
-    #           useGlobalPkgs = true;
-    #           useUserPackages = true;
-    #           users.${variables.user} = import ./modules/nixos/home-manager.nix;
-    #         };
-    #       }
-    #       ./hosts/vm
-    #     ];
-    #   });
-    # };
-      
-    nixosConfigurations = 
-      let
-        mkHost = host: system: nixpkgs.lib.nixosSystem {
-          inherit system;
-          specialArgs = inputs // { inherit variables; };
-          modules = [
-            disko.nixosModules.disko
-            home-manager.nixosModules.home-manager {
-              home-manager = {
-                extraSpecialArgs = { inherit variables; };
-                useGlobalPkgs = true;
-                useUserPackages = true;
-                users.${variables.user} = import ./modules/nixos/home-manager.nix;
-              };
-            }
-            ./hosts/${host}
-          ];
+      nixosConfigurations = 
+        let
+          mkNixos = host: system: nixpkgs.lib.nixosSystem {
+            inherit system;
+            specialArgs = { inherit variables inputs; };
+            modules = [
+              disko.nixosModules.disko
+              home-manager.nixosModules.home-manager 
+              ./hosts/${host}
+            ];
+          };
+        in
+          {
+          "nixos-x86_64" = mkNixos "nixos" "x86_64-linux";
+          "nixos-aarch64" = mkNixos "nixos" "aarch64-linux";
+          "vm-x86_64" = mkNixos "vm" "x86_64-linux";
+          "vm-aarch64" = mkNixos "vm" "aarch64-linux";
+          # "wsl-x86_64" = mkNixos "wsl" "x86_64-linux" ./modules/wsl/home-manager.nix;
+          # "wsl-aarch64" = mkNixos "wsl" "aarch64-linux" ./modules/wsl/home-manager.nix;
         };
-      in
-      {
-        "nixos-x86_64" = mkHost "nixos" "x86_64-linux";
-        "nixos-aarch64" = mkHost "nixos" "aarch64-linux";
-        "vm-x86_64" = mkHost "vm" "x86_64-linux";
-        "vm-aarch64" = mkHost "vm" "aarch64-linux";
-      };
-
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,11 @@
         email = "bassim101@gmail.com";
         userName = "bassim-nix";
         fullName = "Bassim Shahidy";
-        hostName.nixos = "nixos";
-        hostName.vm = "nixos-vm";
-        hostName.darwin = "nixos-mac";
+        hostName = {
+          nixos = "nixos";
+          vm = "nixos-vm";
+          darwin = "nixos-mac";
+        };
       };
       linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
       darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
@@ -122,8 +124,8 @@
           "nixos-aarch64" = mkNixos "nixos" "aarch64-linux";
           "vm-x86_64" = mkNixos "vm" "x86_64-linux";
           "vm-aarch64" = mkNixos "vm" "aarch64-linux";
-          # "wsl-x86_64" = mkNixos "wsl" "x86_64-linux" ./modules/wsl/home-manager.nix;
-          # "wsl-aarch64" = mkNixos "wsl" "aarch64-linux" ./modules/wsl/home-manager.nix;
+          # "wsl-x86_64" = mkNixos "wsl" "x86_64-linux";
+          # "wsl-aarch64" = mkNixos "wsl" "aarch64-linux";
         };
     };
 }

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -1,9 +1,10 @@
 { pkgs, variables, ... }:
 
-let 
-  user = variables.user;
-in 
-  {
+let
+  hostName = variables.hostName.darwin;
+  localHostName = hostName;
+in
+{
   imports = [
     ../../modules/darwin/home-manager.nix
     ../../modules/shared/cachix
@@ -13,25 +14,12 @@ in
   # Auto upgrade nix package and the daemon service.
   services.nix-daemon.enable = true;
 
-  # Nix settings
-  nix = {
-    package = pkgs.nix;
-    settings.trusted-users = [ "@admin" "${user}" ];
-
-    gc = {
-      user = "root";
-      automatic = true;
-      interval = { Weekday = 0; Hour = 2; Minute = 0; };
-      options = "--delete-older-than 30d";
-    };
-
-    extraOptions = ''
-      experimental-features = nix-command flakes
-    '';
-  };
-
   # Turn off NIX_PATH warnings now that we're using flakes
   system.checks.verifyNixPath = false;
+
+  networking = {
+    inherit hostName localHostName;
+  };
 
   environment.systemPackages = with pkgs; [ git ];
 

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -1,6 +1,7 @@
 { pkgs, variables, ... }:
 
 let
+  inherit (variables) userName;
   hostName = variables.hostName.darwin;
   localHostName = hostName;
 in
@@ -10,6 +11,13 @@ in
     ../../modules/shared/cachix
     ../../modules/shared
   ];
+
+  users.users.${userName} = {
+    name = "${userName}";
+    home = "/Users/${userName}";
+    isHidden = false;
+    shell = pkgs.zsh;
+  };
 
   # Auto upgrade nix package and the daemon service.
   services.nix-daemon.enable = true;

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -1,15 +1,32 @@
 { pkgs, variables, ... }:
 
-let 
-    user = variables.user;
-    hostName = variables.hostName.nixos;
+let
+  inherit (variables) userName;
+  hostName = variables.hostName.nixos;
 in
 {
   imports = [
+    ../../modules/nixos/home-manager.nix
     ../../modules/nixos/disk-config.nix
     ../../modules/shared/cachix
     ../../modules/shared
   ];
+
+  users.users.${userName} = {
+    isNormalUser = true;
+    extraGroups = [
+      "wheel" # Enable ‘sudo’ for the user.
+      "docker"
+    ];
+    shell = pkgs.zsh;
+    # openssh.authorizedKeys.keys = keys;
+  };
+
+  # users.users.root = {
+  #   openssh.authorizedKeys.keys = keys;
+  # };
+
+  time.timeZone = "America/New_York";
 
   # Use the systemd-boot EFI boot loader.
   boot = {
@@ -20,49 +37,45 @@ in
       };
       efi.canTouchEfiVariables = true;
     };
-    initrd.availableKernelModules = [ "xhci_pci" "ahci" "nvme" "usbhid" "usb_storage" "sd_mod" ];
+    initrd.availableKernelModules = [
+      "xhci_pci"
+      "ahci"
+      "nvme"
+      "usbhid"
+      "usb_storage"
+      "sd_mod"
+    ];
     # Uncomment for AMD GPU
     # initrd.kernelModules = [ "amdgpu" ];
     kernelPackages = pkgs.linuxPackages_latest;
     # kernelModules = [ "uinput" ];
   };
 
-  # Set your time zone.
-  time.timeZone = "America/New_York";
-
   # The global useDHCP flag is deprecated, therefore explicitly set to false here.
   # Per-interface useDHCP will be mandatory in the future, so this generated config
   # replicates the default behaviour.
   networking = {
-    hostName = hostName; # Define your hostName.
+    inherit hostName;
     useDHCP = false;
     interfaces."%INTERFACE%".useDHCP = true;
   };
 
-  # Turn on flag for proprietary software
-  nix = {
-    nixPath = [ "nixos-config=/home/${user}/.local/share/src/nixos-config:/etc/nixos" ];
-    settings.allowed-users = [ "${user}" ];
-    package = pkgs.nix;
-    extraOptions = ''
-      experimental-features = nix-command flakes
-    '';
-   };
-
   # Manages keys and such
   programs = {
+    zsh.enable = true;
     gnupg.agent.enable = true;
 
     # Needed for anything GTK related
     dconf.enable = true;
-
-    # My shell
-    zsh.enable = true;
   };
 
-  services = { 
+  services = {
     xserver = {
       enable = true;
+      displayManager.gdm.enable = true;
+      desktopManager.gnome.enable = true;
+      xkb.layout = "us";
+      # xkbOptions = "ctrl:nocaps";
 
       # Uncomment these for AMD or Nvidia GPU
       # boot.initrd.kernelModules = [ "amdgpu" ];
@@ -76,15 +89,9 @@ in
       #   Option       "AllowIndirectGLXProtocol" "off"
       #   Option       "TripleBuffer" "on"
       # '';
-
-      displayManager.gdm.enable = true;
-      desktopManager.gnome.enable = true;
-
-      xkb.layout = "us";
-      # xkbOptions = "ctrl:nocaps";
-
-      # Better support for general peripherals
     };
+
+    # Better support for general peripherals
     libinput.enable = true;
 
     # Let's be able to SSH into this machine
@@ -93,17 +100,6 @@ in
     # Enable CUPS to print documents
     # printing.enable = true;
     # printing.drivers = [ pkgs.brlaser ]; # Brother printer driver
-
-    # Picom, my window compositor with fancy effects
-    #
-    # Notes on writing exclude rules:
-    #
-    #   class_g looks up index 1 in WM_CLASS value for an application
-    #   class_i looks up index 0
-    #
-    #   To find the value for a specific application, use `xprop` at the
-    #   terminal and then click on a window of the application in question
-    #
 
     gvfs.enable = true; # Mount, trash, and other functionalities
     tumbler.enable = true; # Thumbnail support for images
@@ -122,7 +118,6 @@ in
     # hardware.xone.enable = true;
   };
 
-
   # Add docker daemon
   # virtualisation = {
   #   docker = {
@@ -131,33 +126,14 @@ in
   #   };
   # };
 
-  # It's me, it's you, it's everyone
-  users.users = {
-    ${user} = {
-      isNormalUser = true;
-      extraGroups = [
-        "wheel" # Enable ‘sudo’ for the user.
-        "docker"
-      ];
-      shell = pkgs.zsh;
-      # openssh.authorizedKeys.keys = keys;
-    };
-
-    # root = {
-    #   openssh.authorizedKeys.keys = keys;
-    # };
-  };
-
   # Don't require password for users in `wheel` group for these commands
   security.sudo = {
     enable = true;
     extraRules = [{
-      commands = [
-       {
-         command = "${pkgs.systemd}/bin/reboot";
-         options = [ "NOPASSWD" ];
-        }
-      ];
+      commands = [{
+          command = "${pkgs.systemd}/bin/reboot";
+          options = [ "NOPASSWD" ];
+        }];
       groups = [ "wheel" ];
     }];
   };

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -1,15 +1,17 @@
-{ config, pkgs, tokyonight, variables, ... }:
+{ config, pkgs, inputs, variables, ... }:
 
 let
-  user = variables.user;
+  inherit (variables) userName;
 in
 {
   imports = [ ./dock ];
 
-  # It me
-  users.users.${user} = {
-    name = "${user}";
-    home = "/Users/${user}";
+  # TODO: 
+  # Consider moving this to hosts/darwin/default.nix
+  # Look into diffences in options between darwin and nixos users.users
+  users.users.${userName} = {
+    name = "${userName}";
+    home = "/Users/${userName}";
     isHidden = false;
     shell = pkgs.zsh;
   };
@@ -20,9 +22,6 @@ in
     # onActivation.cleanup = "uninstall";
 
     # These app IDs are from using the mas CLI app
-    # mas = mac app store
-    # https://github.com/mas-cli/mas
-    #
     # $ nix shell nixpkgs#mas
     # $ mas search <app name>
     #
@@ -35,24 +34,20 @@ in
     # };
   };
 
-  # Enable home-manager
   home-manager = {
-    extraSpecialArgs = { inherit variables; };
+    extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;
-    users.${user} =
+    users.${userName} =
       { pkgs, config, lib, ... }: {
         home = {
           enableNixpkgsReleaseCheck = false;
           stateVersion = "23.11";
         };
         imports = [
-          tokyonight.homeManagerModules.default
           ./files.nix
           ./packages.nix
           ../shared/programs.nix
         ];
-        tokyonight.enable = true;
-        tokyonight.style = "night";
         xdg.enable = true;
         # Marked broken Oct 20, 2022 check later to remove this workaround
         # https://github.com/nix-community/home-manager/issues/3344
@@ -79,12 +74,12 @@ in
     { path = "/System/Applications/Utilities/Activity Monitor.app/"; }
     { path = "/System/Applications/System Settings.app/"; }
     {
-      path = "${config.users.users.${user}.home}/.local/share/";
+      path = "${config.users.users.${userName}.home}/.local/share/";
       section = "others";
       options = "--sort name --view grid --display folder";
     }
     {
-      path = "${config.users.users.${user}.home}/Downloads";
+      path = "${config.users.users.${userName}.home}/Downloads";
       section = "others";
       options = "--sort dateadded --view grid --display stack";
     }

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -6,34 +6,6 @@ in
 {
   imports = [ ./dock ];
 
-  # TODO: 
-  # Consider moving this to hosts/darwin/default.nix
-  # Look into diffences in options between darwin and nixos users.users
-  users.users.${userName} = {
-    name = "${userName}";
-    home = "/Users/${userName}";
-    isHidden = false;
-    shell = pkgs.zsh;
-  };
-
-  homebrew = {
-    enable = true;
-    casks = pkgs.callPackage ./casks.nix { };
-    # onActivation.cleanup = "uninstall";
-
-    # These app IDs are from using the mas CLI app
-    # $ nix shell nixpkgs#mas
-    # $ mas search <app name>
-    #
-    # If you have previously added these apps to your Mac App Store profile (but not installed them on this system),
-    # you may receive an error message "Redownload Unavailable with This Apple ID".
-    # This message is safe to ignore. (https://github.com/dustinlyons/nixos-config/issues/83)
-    # masApps = {
-    #   "1password" = 1333542190;
-    #   "wireguard" = 1451685025;
-    # };
-  };
-
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;

--- a/modules/nixos/home-manager.nix
+++ b/modules/nixos/home-manager.nix
@@ -1,32 +1,40 @@
-{ pkgs, variables, ... }:
+{ variables, inputs, ... }:
 
 let
-  user = variables.user;
+  inherit (variables) userName;
 in
 {
-  imports = [
-    ./files.nix
-    ./packages.nix
-    ../shared/programs.nix
-  ];
+  home-manager = {
+    extraSpecialArgs = { inherit variables inputs; };
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    users.${userName} =
+      { pkgs, config, lib, ... }: {
+        home = {
+          enableNixpkgsReleaseCheck = false;
+          username = "${userName}";
+          homeDirectory = "/home/${userName}";
+          stateVersion = "21.05";
+        };
 
-  home = {
-    enableNixpkgsReleaseCheck = false;
-    username = "${user}";
-    homeDirectory = "/home/${user}";
-    stateVersion = "21.05";
-  };
+        imports = [
+          ./files.nix
+          ./packages.nix
+          ../shared/programs.nix
+        ];
 
-  # Use a dark theme
-  gtk = {
-    enable = true;
-    iconTheme = {
-      name = "Adwaita-dark";
-      package = pkgs.adwaita-icon-theme;
-    };
-    theme = {
-      name = "Adwaita-dark";
-      package = pkgs.adwaita-icon-theme;
-    };
+        # Use a dark theme
+        gtk = {
+          enable = true;
+          iconTheme = {
+            name = "Adwaita-dark";
+            package = pkgs.adwaita-icon-theme;
+          };
+          theme = {
+            name = "Adwaita-dark";
+            package = pkgs.adwaita-icon-theme;
+          };
+        };
+      };
   };
 }

--- a/modules/shared/default.nix
+++ b/modules/shared/default.nix
@@ -1,31 +1,7 @@
 { ... }:
 
 {
-  nixpkgs = {
-    config = {
-      allowUnfree = true;
-      allowBroken = true;
-      allowInsecure = false;
-      allowUnsupportedSystem = true;
-    };
-
-    overlays = (
-      # Apply each overlay found in the /overlays directory
-      let
-        path = ../../overlays;
-      in
-      with builtins;
-      map (n: import (path + ("/" + n))) (
-        filter (n: match ".*\\.nix" n != null || pathExists (path + ("/" + n + "/default.nix"))) (
-          attrNames (readDir path)
-        )
-      )
-
-      # Example for getting overlay as tarball from github
-      # ++ [(import (builtins.fetchTarball {
-      #          url = "https://github.com/dustinlyons/emacs-overlay/archive/refs/heads/master.tar.gz";
-      #          sha256 = "06413w510jmld20i4lik9b36cfafm501864yq8k4vxl5r4hn0j0h";
-      #      }))] 
-    );
-  };
+  imports = [
+    ./nix.nix
+  ];
 }

--- a/modules/shared/nix.nix
+++ b/modules/shared/nix.nix
@@ -9,20 +9,6 @@ in
     settings.allowed-users = [ "${userName}" ];
     settings.trusted-users = [ "@admin" "${userName}" ];
 
-    # gc = lib.mkMerge [
-    #   {
-    #     automatic = true;
-    #     options = "--delete-older-than 30d";
-    #   }
-    #   (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-    #     user = "root";
-    #     interval = { Weekday = 0; Hour = 2; Minute = 0; };
-    #   })
-    #   (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
-    #     dates = "weekly";
-    #   })
-    # ];
-
     gc =
       {
         automatic = true;

--- a/modules/shared/nix.nix
+++ b/modules/shared/nix.nix
@@ -1,0 +1,71 @@
+{ pkgs, variables, lib, ... }:
+
+let
+  inherit (variables) userName;
+in
+{
+  nix = {
+    package = pkgs.nix;
+    settings.allowed-users = [ "${userName}" ];
+    settings.trusted-users = [ "@admin" "${userName}" ];
+
+    # gc = lib.mkMerge [
+    #   {
+    #     automatic = true;
+    #     options = "--delete-older-than 30d";
+    #   }
+    #   (lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+    #     user = "root";
+    #     interval = { Weekday = 0; Hour = 2; Minute = 0; };
+    #   })
+    #   (lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+    #     dates = "weekly";
+    #   })
+    # ];
+
+    gc =
+      {
+        automatic = true;
+        options = "--delete-older-than 30d";
+      }
+      // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+        user = "root";
+        interval = { Weekday = 0; Hour = 2; Minute = 0; };
+      }
+      // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+        dates = "weekly";
+      };
+
+    extraOptions = ''
+      experimental-features = nix-command flakes
+    '';
+  };
+
+  nixpkgs = {
+    config = {
+      allowUnfree = true;
+      allowBroken = true;
+      allowInsecure = false;
+      allowUnsupportedSystem = true;
+    };
+
+    overlays = (
+      # Apply each overlay found in the /overlays directory
+      let
+        path = ../../overlays;
+      in
+      with builtins;
+      map (n: import (path + ("/" + n))) (
+        filter (n: match ".*\\.nix" n != null || pathExists (path + ("/" + n + "/default.nix"))) (
+          attrNames (readDir path)
+        )
+      )
+
+      # Example for getting overlay as tarball from github
+      # ++ [(import (builtins.fetchTarball {
+      #          url = "https://github.com/dustinlyons/emacs-overlay/archive/refs/heads/master.tar.gz";
+      #          sha256 = "06413w510jmld20i4lik9b36cfafm501864yq8k4vxl5r4hn0j0h";
+      #      }))] 
+    );
+  };
+}

--- a/modules/shared/programs.nix
+++ b/modules/shared/programs.nix
@@ -1,11 +1,15 @@
-{ pkgs, lib, variables, ... }:
+{ pkgs, lib, variables, inputs, ... }:
 
 let
-  name = variables.fullName;
-  user = variables.user;
-  email = variables.email;
+  inherit (variables) userName fullName email;
 in
 {
+  imports = [
+    inputs.tokyonight.homeManagerModules.default
+  ];
+  tokyonight.enable = true;
+  tokyonight.style = "night";
+
   programs = {
     # -----------------------
     # -- zsh configuration --
@@ -136,11 +140,7 @@ in
       settings = {
         manager = {
           show_hidden = true;
-          ratio = [
-            1
-            3
-            4
-          ];
+          ratio = [ 1 3 4 ];
         };
       };
     };
@@ -148,15 +148,15 @@ in
     ssh = {
       enable = true;
       includes = [
-        (lib.mkIf pkgs.stdenv.hostPlatform.isLinux "/home/${user}/.ssh/config_external")
-        (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin "/Users/${user}/.ssh/config_external")
+        (lib.mkIf pkgs.stdenv.hostPlatform.isLinux "/home/${userName}/.ssh/config_external")
+        (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin "/Users/${userName}/.ssh/config_external")
       ];
       matchBlocks = {
         "github.com" = {
           identitiesOnly = true;
           identityFile = [
-            (lib.mkIf pkgs.stdenv.hostPlatform.isLinux "/home/${user}/.ssh/id_github")
-            (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin "/Users/${user}/.ssh/id_github")
+            (lib.mkIf pkgs.stdenv.hostPlatform.isLinux "/home/${userName}/.ssh/id_github")
+            (lib.mkIf pkgs.stdenv.hostPlatform.isDarwin "/Users/${userName}/.ssh/id_github")
           ];
         };
       };
@@ -253,7 +253,7 @@ in
     git = {
       enable = true;
       ignores = [ "*.swp" ];
-      userName = name;
+      userName = fullName;
       userEmail = email;
       signing = {
         key = "~/.ssh/id_github";


### PR DESCRIPTION
### What Changed
Overhaul of nixos-config: relocations and refactoring to achieve configuration parity between hosts in addition to improving overall code and structure.

#### Refactoring
- Rename `user` to `userName` for consistency
- Update `mkHost` to accommodate relocated Home Manager top-level config
- Change `{ inherit inputs variables }` to pass `inputs` directly instead of `inputs // { inherit variables }`
- Use inherit destructuring like `inherit (variables) userName` instead of `userName = variables.userName`

#### Config Updates and Relocation
- Move `users.users` from `darwin/home-manager` to `hosts/darwin`
- Relocate Home Manager top-level config for NixOS from `flake.nix` to `nixos/home-manager.nix`
- Import NixOS Home Manager files in `hosts/**/default.nix` instead of `flake.nix`
- Transfer Nix settings to `nix.nix`:
  - Apply conditionals for per-system garbage collection settings
  - Remove unnecessary `nix.nixPath` configuration
- Move `tokyonight` from `darwin/home-manager.nix` to `programs.nix`, enabling it for all systems.
- Add `localHostName` to `darwin/default.nix`:
  - Set `localHostName = hostName`
  - Use `{ inherit hostName localHostName }` to set networking settings
