### PR TITLE
refactor(darwin): Achieve parity with nixos config

### DIFF
--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -1,6 +1,7 @@
 { pkgs, variables, ... }:
 
 let
+  inherit (variables) userName;
   hostName = variables.hostName.darwin;
   localHostName = hostName;
 in
@@ -10,6 +11,13 @@ in
     ../../modules/shared/cachix
     ../../modules/shared
   ];
+
+  users.users.${userName} = {
+    name = "${userName}";
+    home = "/Users/${userName}";
+    isHidden = false;
+    shell = pkgs.zsh;
+  };
 
   # Auto upgrade nix package and the daemon service.
   services.nix-daemon.enable = true;

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -6,34 +6,6 @@ in
 {
   imports = [ ./dock ];
 
-  # TODO: 
-  # Consider moving this to hosts/darwin/default.nix
-  # Look into diffences in options between darwin and nixos users.users
-  users.users.${userName} = {
-    name = "${userName}";
-    home = "/Users/${userName}";
-    isHidden = false;
-    shell = pkgs.zsh;
-  };
-
-  homebrew = {
-    enable = true;
-    casks = pkgs.callPackage ./casks.nix { };
-    # onActivation.cleanup = "uninstall";
-
-    # These app IDs are from using the mas CLI app
-    # $ nix shell nixpkgs#mas
-    # $ mas search <app name>
-    #
-    # If you have previously added these apps to your Mac App Store profile (but not installed them on this system),
-    # you may receive an error message "Redownload Unavailable with This Apple ID".
-    # This message is safe to ignore. (https://github.com/dustinlyons/nixos-config/issues/83)
-    # masApps = {
-    #   "1password" = 1333542190;
-    #   "wireguard" = 1451685025;
-    # };
-  };
-
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;


### PR DESCRIPTION
Move `users.users` config from `darwin/home-manager` to `hosts/darwin`