### PR TITLE
feat: Add fish shell option, put optional shells `in shared/shells/`

### DIFF
--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -13,11 +13,13 @@ in
     ../../modules/shared
   ];
 
+  shells.zsh.enable = true;
+  shells.fish.enable = false;
+
   users.users.${userName} = {
     name = "${userName}";
     home = "/Users/${userName}";
     isHidden = false;
-    shell = pkgs.zsh;
   };
 
   # Auto upgrade nix package and the daemon service.

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -12,13 +12,15 @@ in
     ../../modules/shared
   ];
 
+  shells.zsh.enable = true;
+  shells.fish.enable = false;
+
   users.users.${userName} = {
     isNormalUser = true;
     extraGroups = [
       "wheel" # Enable ‘sudo’ for the user.
       "docker"
     ];
-    shell = pkgs.zsh;
     # openssh.authorizedKeys.keys = keys;
   };
 

--- a/hosts/vm/default.nix
+++ b/hosts/vm/default.nix
@@ -12,13 +12,15 @@ in
     ../../modules/shared
   ];
 
+  shells.zsh.enable = true;
+  shells.fish.enable = false;
+
   users.users.${userName} = {
     isNormalUser = true;
     extraGroups = [
       "wheel" # Enable ‘sudo’ for the user.
       "docker"
     ];
-    shell = pkgs.zsh;
     # openssh.authorizedKeys.keys = keys;
   };
 

--- a/modules/shared/default.nix
+++ b/modules/shared/default.nix
@@ -1,7 +1,23 @@
-{ ... }:
+{ lib, ... }:
 
 {
   imports = [
     ./nix.nix
+    ./shells/zsh.nix
+    ./shells/fish.nix
   ];
+
+  options.shells = {
+    # Provides `shells.activeShell` option used in ./shells/*
+    # Each shell module sets `shells.activeShell` to the shell name
+    #
+    # Programs can enable shell specific options with `shells.activeShell`:
+    # `enableFishIntegration = config.shells.activeShell == "fish";`
+    #
+    activeShell = lib.mkOption {
+      type = lib.types.enum [ "none" "zsh" "fish" "bash" ];
+      default = "none";
+      description = "Currently active shell";
+    };
+  };
 }

--- a/modules/shared/default.nix
+++ b/modules/shared/default.nix
@@ -20,4 +20,9 @@
       description = "Currently active shell";
     };
   };
+
+  config = {
+    # TODO: Find a better place to put this
+    environment.variables.EDITOR = "nvim";
+  };
 }

--- a/modules/shared/programs.nix
+++ b/modules/shared/programs.nix
@@ -42,9 +42,11 @@ in
         "--border"
       ];
       fileWidgetCommand = "fd --hidden --strip-cwd-prefix --exclude .git";
-      fileWidgetOptions = [
-        "--preview 'if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'"
-      ];
+      fileWidgetOptions =
+        if isFish then
+          [ "--preview 'if test -d {}; eza --tree --all --level=3 --color=always {} | head -200; else; bat -n --color=always --line-range :500 {}; end'" ]
+        else
+          [ "--preview 'if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'" ];
       changeDirWidgetCommand = "fd --type d --hidden --strip-cwd-prefix --exclude .git";
       changeDirWidgetOptions = [ "--preview 'eza --tree --color=always {} | head -200'" ];
     };

--- a/modules/shared/programs.nix
+++ b/modules/shared/programs.nix
@@ -1,7 +1,15 @@
-{ pkgs, lib, variables, inputs, ... }:
+{ pkgs, lib, variables, inputs, osConfig, ... }:
 
 let
   inherit (variables) userName fullName email;
+
+  # `osConfig` allows us to access the top level nixos `config`,
+  # while `config` in this file would otherwise be home-manager's
+  #
+  # This makes shells.activeShell available, even though it's 
+  # defined and passed at the nix level, not directly to home-manager
+  isFish = osConfig.shells.activeShell == "fish";
+  isZsh = osConfig.shells.activeShell == "zsh";
 in
 {
   imports = [
@@ -11,89 +19,10 @@ in
   tokyonight.style = "night";
 
   programs = {
-    # -----------------------
-    # -- zsh configuration --
-    # -----------------------
-    zsh = {
-      enable = true;
-      autocd = false;
-      autosuggestion.enable = true;
-      syntaxHighlighting.enable = true;
-      enableCompletion = true;
-      shellAliases = {
-        # General aliases
-        g = "git";
-        zrc = "nvim ~/.zshrc";
-        szrc = "source ~/.zshrc";
-        exz = "exec zsh";
-        cl = "clear";
-        yz = "yazi";
-        lg = "lazygit";
-        # Nix aliases
-        nixswitch = "git add . && nix run .#build-switch";
-        nixbuild = "git add . && nix run .#build";
-        ns = "nixswitch";
-        nb = "nixbuild";
-        # Eza aliases
-        l = "eza --git --icons=always --color=always --long --no-user --no-permissions --no-filesize --no-time";
-        la = "eza --git --icons=always --color=always --long --no-user --no-permissions --no-filesize --no-time --all";
-        ls = "l";
-        lsa = "la";
-        lsl = "eza --git --icons=always --color=always --long --no-user";
-        ll = "eza --git --icons=always --color=always --long --no-user -all";
-        lt = "eza --git --icons=always --color=always --long --no-user -all --tree --level=2";
-        lt2 = "eza --git --icons=always --color=always --long --no-user -all --tree --level=3";
-        lt3 = "eza --git --icons=always --color=always --long --no-user -all --tree --level=4";
-        ltg = "eza --git --icons=always --color=always --long --no-user --tree --git-ignore";
-      };
-      initExtra = ''
-        # Advanced customization of fzf options via _fzf_comprun function
-        _fzf_comprun() {
-          local command=$1
-          shift
-
-          case "$command" in
-            cd)           fzf --preview 'eza --tree --color=always {} | head -200' "$@" ;;
-            export|unset) fzf --preview "eval 'echo $'{}"         "$@" ;;
-            ssh)          fzf --preview 'dig {}'                   "$@" ;;
-            *)            fzf --preview "bat -n --color=always --line-range :500 {}" "$@" ;;
-          esac
-        }
-
-
-        # -- fzf with bat and eza previews --
-        show_file_or_dir_preview='if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'
-        alias lspe="fzf --preview '$show_file_or_dir_preview'"
-        alias lsp="fd --max-depth 1 --hidden --follow --exclude .git | fzf --preview '$show_file_or_dir_preview'"
-      '';
-      plugins = [
-        {
-          name = "fzf-git-sh";
-          src = pkgs.fzf-git-sh;
-          file = "share/fzf-git-sh/fzf-git.sh";
-        }
-      ];
-      initExtraFirst = ''
-        if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
-        fi
-
-        # Define variables for directories
-        export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
-        export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
-        export PATH=$HOME/.local/share/bin:$PATH
-
-        # Remove history data we don't want to see
-        export HISTIGNORE="pwd:ls:cd"
-
-        export EDITOR=nvim
-      '';
-    };
-
     oh-my-posh = {
       enable = true;
-      enableZshIntegration = true;
+      enableZshIntegration = isZsh;
+      enableFishIntegration = isFish;
       useTheme = "tokyonight_storm";
     };
 
@@ -105,8 +34,8 @@ in
 
     fzf = {
       enable = true;
-      enableZshIntegration = true;
-      defaultCommand = "fd --hidden --strip-cwd-prefix --exclude .git";
+      enableZshIntegration = isZsh;
+      enableFishIntegration = isFish;
       defaultOptions = [
         "--height 40%"
         "--layout=reverse"
@@ -122,7 +51,8 @@ in
 
     zoxide = {
       enable = true;
-      enableZshIntegration = true;
+      enableZshIntegration = isZsh;
+      enableFishIntegration = isFish;
       options = [
         "--cmd cd"
       ];
@@ -136,7 +66,8 @@ in
 
     yazi = {
       enable = true;
-      enableZshIntegration = true;
+      enableZshIntegration = isZsh;
+      enableFishIntegration = isFish;
       settings = {
         manager = {
           show_hidden = true;
@@ -561,7 +492,7 @@ in
 
     wezterm = {
       enable = true;
-      enableZshIntegration = true;
+      enableZshIntegration = isZsh;
       extraConfig = ''
         local wezterm = require("wezterm")
 

--- a/modules/shared/shells/fish.nix
+++ b/modules/shared/shells/fish.nix
@@ -1,0 +1,71 @@
+{ pkgs, lib, config, variables, ... }:
+let
+  inherit (lib) mkIf mkEnableOption mkMerge optionalAttrs;
+  inherit (variables) userName;
+  fish = config.shells.fish;
+in
+{
+  # Enable fish with:
+  # `shells.fish.enable = true;`
+
+  # Set shell per host in:
+  # hosts/<host>/default.nix or modules/<host>/home-manager.nix
+
+  # Set shell for all hosts in:
+  # modules/shared/default.nix
+
+  options.shells.fish = {
+    enable = mkEnableOption "fish shell";
+  };
+
+  config = mkIf fish.enable {
+
+    # Programs can conditionally enable shell specific integrations
+    # by accessing `shells.activeShell`. For example:
+    # `enableZshIntegration = config.shells.activeShell == "zsh";`
+    shells.activeShell = "fish";
+
+    home-manager.users.${userName}.programs.fish = {
+      enable = true;
+      shellAbbrs = {
+        # General aliases
+        g   = "git";
+        zrc = "nvim ~/.zshrc";
+        szrc = "source ~/.zshrc";
+        exz = "exec zsh";
+        cl  = "clear";
+        yz  = "yazi";
+        lg  = "lazygit";
+        # Nix aliases
+        ns  = "git add . && nix run .#build-switch";
+        nb  = "git add . && nix run .#build";
+        # Eza aliases
+        ls  = "eza --git --icons=always --color=always --long --no-user --no-permissions --no-filesize --no-time";
+        lsa = "eza --git --icons=always --color=always --long --no-user --no-permissions --no-filesize --no-time --all";
+        l   = "eza --git --icons=always --color=always --long --no-filesize";
+        la  = "eza --git --icons=always --color=always --long --no-filesize -all";
+        lt  = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=2";
+        lt2 = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=3";
+        lt3 = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=4";
+        ltg = "eza --git --icons=always --color=always --long --no-filesize --tree --git-ignore";
+      };
+    };
+
+    # Set nix managed system shell
+    environment.shells = [ pkgs.fish ];
+    programs.fish.enable = true;
+
+    # Make sure nix managed shell is used by default
+    users = mkMerge [
+      { users.${userName}.shell = pkgs.fish; }
+
+      (optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+        # knownUsers may not be the best way to do this
+        # setup nix managed shell in nix-darwin
+        # https://github.com/LnL7/nix-darwin/issues/811#issuecomment-2227568956
+        knownUsers = [ userName ];
+        users.${userName}.uid = 501;
+      })
+    ];
+  };
+}

--- a/modules/shared/shells/fish.nix
+++ b/modules/shared/shells/fish.nix
@@ -30,8 +30,6 @@ in
       shellAbbrs = {
         # General aliases
         g   = "git";
-        zrc = "nvim ~/.zshrc";
-        szrc = "source ~/.zshrc";
         exz = "exec zsh";
         cl  = "clear";
         yz  = "yazi";

--- a/modules/shared/shells/zsh.nix
+++ b/modules/shared/shells/zsh.nix
@@ -1,0 +1,118 @@
+{ pkgs, lib, config, variables, ... }:
+let
+  inherit (lib) mkIf mkEnableOption mkMerge optionalAttrs;
+  inherit (variables) userName;
+  zsh = config.shells.zsh;
+in
+{
+  # Enable zsh with:
+  # shells.zsh.enable = true;
+
+  # Set shell per host in:
+  # hosts/<host>/default.nix or modules/<host>/home-manager.nix
+
+  # Set shell for all hosts in:
+  # modules/shared/default.nix
+
+  options.shells.zsh = {
+    enable = mkEnableOption "zsh shell";
+  };
+
+  config = mkIf zsh.enable {
+
+    # Programs can conditionally enable shell specific integrations
+    # by accessing `shells.activeShell`. For example:
+    # `enableZshIntegration = config.shells.activeShell == "zsh";`
+    shells.activeShell = "zsh";
+
+    home-manager.users.${userName}.programs.zsh = {
+      enable = true;
+      autocd = false;
+      autosuggestion.enable = true;
+      syntaxHighlighting.enable = true;
+      enableCompletion = true;
+      shellAliases = {
+        # General aliases
+        g   = "git";
+        zrc = "nvim ~/.zshrc";
+        szrc = "source ~/.zshrc";
+        exz = "exec zsh";
+        cl  = "clear";
+        yz  = "yazi";
+        lg  = "lazygit";
+        # Nix aliases
+        ns  = "git add . && nix run .#build-switch";
+        nb  = "git add . && nix run .#build";
+        # Eza aliases
+        ls  = "eza --git --icons=always --color=always --long --no-user --no-permissions --no-filesize --no-time";
+        lsa = "eza --git --icons=always --color=always --long --no-user --no-permissions --no-filesize --no-time --all";
+        l   = "eza --git --icons=always --color=always --long --no-filesize";
+        la  = "eza --git --icons=always --color=always --long --no-filesize -all";
+        lt  = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=2";
+        lt2 = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=3";
+        lt3 = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=4";
+        ltg = "eza --git --icons=always --color=always --long --no-filesize --tree --git-ignore";
+      };
+      initExtra = /*bash*/ ''
+        # Advanced customization of fzf options via _fzf_comprun function
+        _fzf_comprun() {
+          local command=$1
+          shift
+
+          case "$command" in
+            cd)           fzf --preview 'eza --tree --color=always {} | head -200' "$@" ;;
+            export|unset) fzf --preview "eval 'echo $'{}"         "$@" ;;
+            ssh)          fzf --preview 'dig {}'                   "$@" ;;
+            *)            fzf --preview "bat -n --color=always --line-range :500 {}" "$@" ;;
+          esac
+        }
+
+
+        # -- fzf with bat and eza previews --
+        show_file_or_dir_preview='if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'
+        alias lspe="fzf --preview '$show_file_or_dir_preview'"
+        alias lsp="fd --max-depth 1 --hidden --follow --exclude .git | fzf --preview '$show_file_or_dir_preview'"
+      '';
+      plugins = [
+        {
+          name = "fzf-git-sh";
+          src = pkgs.fzf-git-sh;
+          file = "share/fzf-git-sh/fzf-git.sh";
+        }
+      ];
+      initExtraFirst = /*bash*/ ''
+        if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+        fi
+
+        # Define variables for directories
+        export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
+        export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
+        export PATH=$HOME/.local/share/bin:$PATH
+
+        # Remove history data we don't want to see
+        export HISTIGNORE="pwd:ls:cd"
+
+        export EDITOR=nvim
+      '';
+    };
+
+    # Set nix managed system shell
+    environment.shells = [ pkgs.zsh ];
+    programs.zsh.enable = true;
+
+    # Make sure nix managed shell is used by default
+    users = mkMerge [
+      { users.${userName}.shell = pkgs.zsh; }
+
+      (optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+        # knownUsers may not be the best way to
+        # setup nix managed shell in nix-darwin
+        # https://github.com/LnL7/nix-darwin/issues/811#issuecomment-2227568956
+        knownUsers = [ userName ];
+        users.${userName}.uid = 501;
+      })
+    ];
+  };
+}

--- a/modules/shared/shells/zsh.nix
+++ b/modules/shared/shells/zsh.nix
@@ -34,8 +34,6 @@ in
       shellAliases = {
         # General aliases
         g   = "git";
-        zrc = "nvim ~/.zshrc";
-        szrc = "source ~/.zshrc";
         exz = "exec zsh";
         cl  = "clear";
         yz  = "yazi";
@@ -93,8 +91,6 @@ in
 
         # Remove history data we don't want to see
         export HISTIGNORE="pwd:ls:cd"
-
-        export EDITOR=nvim
       '';
     };
 


### PR DESCRIPTION
- Move zsh config to `modules/shared/shells/zsh.nix`, add fish config to
`modules/shared/shells/fish.nix`
- Make each shell optional, add activeShell option definition in
`shared/default.nix` for tracking the currently enabled shell. This is
set in each shells/ file, then used in programs.nix to enable shell
specific integrations with `isZsh` or `isFish`
- Move `$EDITOR` definition to `shared/default.nix`, makes it global, instead of shell specific
- Update `fileWidgetOptions` with conditional that uses fish syntax if using fish, else bash
- Use `knownUsers` with `uid` to enable nix managed shell in nix-darwin
  - Note:  `knownUsers` may not be the best way to do this - https://github.com/LnL7/nix-darwin/issues/811#issuecomment-2227568956