### PR TITLE
feat: Add graphite-cli aliases file with out of store symlink

### DIFF
--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -9,6 +9,7 @@ in
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;
+    backupFileExtension = "hm-bak";
     users.${userName} =
       { pkgs, config, lib, ... }: {
         home = {

--- a/modules/shared/config/graphite/aliases
+++ b/modules/shared/config/graphite/aliases
@@ -1,0 +1,19 @@
+# Edit this file to configure aliases for Graphite commands.
+# If you delete this file, it will be recreated with the default aliases.
+# The first word of each line is the alias, and the rest is the command.
+# Lines starting with # are ignored.
+
+# The aliases for ss, ls, and ll are defined by default and must be overridden to be disabled.
+# They are shown below to demonstrate the formatting.
+
+ls log short
+ll log long
+ss submit --stack
+s submit
+sy sync
+t co --trunk
+dn down
+bm bottom
+ab absorb
+st status
+sts status -s

--- a/modules/shared/config/graphite/aliases
+++ b/modules/shared/config/graphite/aliases
@@ -8,8 +8,9 @@
 
 ls log short
 ll log long
-ss submit --stack
 s submit
+ss submit --stack
+su submit --stack --update-only
 sy sync
 t co --trunk
 dn down
@@ -17,3 +18,4 @@ bm bottom
 ab absorb
 st status
 sts status -s
+rs restack

--- a/modules/shared/default.nix
+++ b/modules/shared/default.nix
@@ -1,39 +1,24 @@
-{ lib, config, variables, ... }:
+{ config, variables, ... }:
 
 {
   imports = [
     ./nix.nix
+    ./options.nix
     ./secrets.nix
     ./shells/zsh.nix
     ./shells/fish.nix
   ];
 
-  options.shells = {
-    # Provides `shells.activeShell` option used in ./shells/*
-    # Each shell module sets `shells.activeShell` to the shell name
-    #
-    # Programs can enable shell specific options with `shells.activeShell`:
-    # `enableFishIntegration = config.shells.activeShell == "fish";`
-    #
-    activeShell = lib.mkOption {
-      type = lib.types.enum [ "none" "zsh" "fish" "bash" ];
-      default = "none";
-      description = "Currently active shell";
+  # TODO: look for way to add env vars as a file in nix
+  environment.variables = {
+    EDITOR = "nvim";
+  };
+
+  home-manager.users.${variables.userName} = {
+    home.sessionVariables = {
+      ANTHROPIC_API_KEY = "`cat ${config.age.secrets.anthropic.path}`";
+      OPENAI_API_KEY = "`cat ${config.age.secrets.openai.path}`";
     };
   };
 
-  config = {
-    # TODO: Find a better place to put this, maybe a new `common.nix` module 
-    # or keep it here and move the above options to a new `options.nix` module
-    environment.variables = {
-      EDITOR = "nvim";
-    };
-
-    home-manager.users.${variables.userName} = {
-      home.sessionVariables = {
-        ANTHROPIC_API_KEY = "`cat ${config.age.secrets.anthropic.path}`";
-        OPENAI_API_KEY = "`cat ${config.age.secrets.openai.path}`";
-      };
-    };
-  };
 }

--- a/modules/shared/files.nix
+++ b/modules/shared/files.nix
@@ -14,5 +14,10 @@
       source = config.lib.file.mkOutOfStoreSymlink 
         "${config.home.homeDirectory}/nixos-config/modules/shared/config/lvim/config.lua";
     };
+
+    "graphite/aliases" = {
+      source = config.lib.file.mkOutOfStoreSymlink 
+        "${config.home.homeDirectory}/nixos-config/modules/shared/config/graphite/aliases";
+    };
   };
 }

--- a/modules/shared/options.nix
+++ b/modules/shared/options.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+{
+  options.shells = {
+    # Provides `shells.activeShell` option used in ./shells/*
+    # Each shell module sets `shells.activeShell` to the shell name
+    #
+    # Programs can enable shell specific options with `shells.activeShell`:
+    # `enableFishIntegration = config.shells.activeShell == "fish";`
+    #
+    activeShell = lib.mkOption {
+      type = lib.types.enum [ "none" "zsh" "fish" "bash" ];
+      default = "none";
+      description = "Currently active shell";
+    };
+  };
+}


### PR DESCRIPTION
### What Changed?
1. **Graphite-CLI Aliases**: Adds a `graphite-cli` aliases file with an out-of-store symbolic link for easier management.
2. **Home-Manager Backup Extension**: Configures a backup file extension for Home-Manager to use when renaming conflicting files before replacing them.
3. **Refactoring**: Extracts options from `default.nix` into a new `options.nix` file for improved modularity and maintainability, while ensuring proper imports in `default.nix`. 