### PR TITLE
refactor: Modularize home-manager modules and update flake 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,7 +8,7 @@
           "ragenix",
           "nixpkgs"
         ],
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1723293904,
@@ -27,16 +27,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1727016223,
-        "narHash": "sha256-iZqd91Cp4O02BU6/eBZ0UZgJN8AlwH+0geQUpqF176E=",
+        "lastModified": 1731323744,
+        "narHash": "sha256-SxUQm4cTHcaoPQHoXe26ZV8cZiMWBGow8MjE4L+MckM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "916044581862c32fc2365e8e9ff0b1507a98925e",
+        "rev": "254bf3fe9d8fa2e1b2fb55dbcf535b2d870180c4",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.3.24",
+        "ref": "4.4.5",
         "repo": "brew",
         "type": "github"
       }
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731153869,
-        "narHash": "sha256-3Ftf9oqOypcEyyrWJ0baVkRpvQqroK/SVBFLvU3nPuc=",
+        "lastModified": 1737926801,
+        "narHash": "sha256-un7IETRNjUm83jM5Gd/7BO4rCzzkom46O0FDMo5toaI=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "5c74ab862c8070cbf6400128a1b56abb213656da",
+        "rev": "62ba0a22426721c94e08f0779ed8235d5672869b",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731274291,
-        "narHash": "sha256-cZ0QMpv5p2a6WEE+o9uu0a4ma6RzQDOQTbm7PbixWz8=",
+        "lastModified": 1737038063,
+        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "486250f404f4a4f4f33f8f669d83ca5f6e6b7dfc",
+        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
         "type": "github"
       },
       "original": {
@@ -122,25 +122,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -163,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731235328,
-        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
+        "lastModified": 1737762889,
+        "narHash": "sha256-5HGG09bh/Yx0JA8wtBMAzt0HMCL1bYZ93x4IqzVExio=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
+        "rev": "daf04c5950b676f47a794300657f1d3d14c1a120",
         "type": "github"
       },
       "original": {
@@ -201,11 +183,11 @@
     "homebrew-bundle": {
       "flake": false,
       "locked": {
-        "lastModified": 1731169403,
-        "narHash": "sha256-UZySsI/AldCICeS8yz/Vau18i2wxm8VuBH1CbOyXT14=",
+        "lastModified": 1737709977,
+        "narHash": "sha256-DvsRUJfrkseHj8mYhh1Zc8EyGX31A4MV0o8Vjlx6egU=",
         "owner": "homebrew",
         "repo": "homebrew-bundle",
-        "rev": "207bc4aaccccda9eb6420ff41716fc19c10618d2",
+        "rev": "ef706d4b71a7a63ca6b50c5c2093e19594d2e024",
         "type": "github"
       },
       "original": {
@@ -217,11 +199,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1731287223,
-        "narHash": "sha256-GVDB09Gv8Jp2EWq6lNF4aGC2GGYbn2mcM0aq2bqAEIs=",
+        "lastModified": 1737939319,
+        "narHash": "sha256-8PrmGqIecs5BJMJVlKsIermgjLJT33sFHiVuaMoEVbw=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "0c13d068b207f497d528327a90356559b75ee847",
+        "rev": "70c09f341c55f28509013ab906334a0ed1e61304",
         "type": "github"
       },
       "original": {
@@ -233,11 +215,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1731285002,
-        "narHash": "sha256-UJcmdoqa5oeJWa9PIm4giodwD/mhaxxlOys98NRFAtY=",
+        "lastModified": 1737938486,
+        "narHash": "sha256-kTqB0E8kHF/poopNLe/EMXQLatNWVkbMZnxn4HyLpJ0=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "08e23797665ccc89ddfb535738ffa3aea8dfe7dc",
+        "rev": "2dee229e4cf1db732298fb4dae0550ae53958c25",
         "type": "github"
       },
       "original": {
@@ -267,18 +249,17 @@
     "nix-homebrew": {
       "inputs": {
         "brew-src": "brew-src",
-        "flake-utils": "flake-utils",
         "nix-darwin": "nix-darwin",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1728153462,
-        "narHash": "sha256-jOF15LIzDf7SIkbjzhKq9nlnkS1aFTUCiIo92ipXMY4=",
+        "lastModified": 1736041957,
+        "narHash": "sha256-Kk/cVtkxwfHNoB6nINUarMLTtyAEvH+ohzxKBptMzzg=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "86af3bb8f7d365eb496ef5553646ec2fe06a3662",
+        "rev": "a6d99cc7436fc18c097b3536d9c45c0548c694c8",
         "type": "github"
       },
       "original": {
@@ -302,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1737885589,
+        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
         "type": "github"
       },
       "original": {
@@ -320,7 +301,7 @@
       "inputs": {
         "agenix": "agenix",
         "crane": "crane",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -391,21 +372,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -6,6 +6,10 @@ in
 {
   imports = [ ./dock ];
 
+  fonts.packages = [
+    pkgs.nerd-fonts.monaspace
+  ];
+
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -4,10 +4,9 @@ let
   inherit (variables) userName;
 in
 {
-  imports = [ ./dock ];
-
-  fonts.packages = [
-    pkgs.nerd-fonts.monaspace
+  imports = [ 
+    ./dock
+    ./packages.nix
   ];
 
   home-manager = {
@@ -22,7 +21,6 @@ in
         };
         imports = [
           ./files.nix
-          ./packages.nix
           ../shared/programs.nix
         ];
         xdg.enable = true;

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -1,9 +1,9 @@
-{ variables, inputs, config, lib, ... }:
+{ variables, inputs, config, ... }:
 let
   inherit (variables) userName;
   inherit (inputs) homebrew-bundle homebrew-core homebrew-cask;
-  inherit (lib) mkIf mkEnableOption;
-  cfg = config.nix-homebrew;
+  # inherit (lib) mkIf mkEnableOption;
+  # cfg = config.nix-homebrew;
 in
 {
   options = {

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -13,20 +13,20 @@ in
     # TODO: PR merged, update and test using nix-darwin interactiveShellInit
     # instead of home-manager shell config like in PR
     #
-    nix-homebrew = {
-      enableZshIntegration = mkEnableOption "homebrew zsh integration" // {
-        default = false;
-      };
-      enableBashIntegration = mkEnableOption "homebrew bash integration" // {
-        default = false;
-      };
-      enableFishIntegration = mkEnableOption "homebrew fish integration" // {
-        default = false;
-      };
-      enableNushellIntegration = mkEnableOption "homebrew nushell integration" // {
-        default = false;
-      };
-    };
+    # nix-homebrew = {
+    #   enableZshIntegration = mkEnableOption "homebrew zsh integration" // {
+    #     default = false;
+    #   };
+    #   enableBashIntegration = mkEnableOption "homebrew bash integration" // {
+    #     default = false;
+    #   };
+    #   enableFishIntegration = mkEnableOption "homebrew fish integration" // {
+    #     default = false;
+    #   };
+    #   enableNushellIntegration = mkEnableOption "homebrew nushell integration" // {
+    #     default = false;
+    #   };
+    # };
   };
 
   config = {
@@ -46,27 +46,27 @@ in
     };
 
     # Homebrew shell integration
-    home-manager.users.${userName}.programs = {
-      zsh.initExtra = mkIf cfg.enableZshIntegration /*bash*/ ''
-        eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
-      '';
-
-      bash.initExtra = mkIf cfg.enableBashIntegration /*bash*/ ''
-        eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
-      '';
-
-      fish.interactiveShellInit = mkIf cfg.enableFishIntegration /*bash*/ ''
-        eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
-      '';
-
-      # https://www.nushell.sh/book/configuration.html#homebrew
-      # https://reimbar.org/dev/nushell/
-      nushell.extraEnv = mkIf cfg.enableFishIntegration /*bash*/ ''
-        # $env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin') 
-        use std "path add"
-        path add /opt/homebrew/bin
-      '';
-    };
+    # home-manager.users.${userName}.programs = {
+    #   zsh.initExtra = mkIf cfg.enableZshIntegration /*bash*/ ''
+    #     eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
+    #   '';
+    #
+    #   bash.initExtra = mkIf cfg.enableBashIntegration /*bash*/ ''
+    #     eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
+    #   '';
+    #
+    #   fish.interactiveShellInit = mkIf cfg.enableFishIntegration /*bash*/ ''
+    #     eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
+    #   '';
+    #
+    #   # https://www.nushell.sh/book/configuration.html#homebrew
+    #   # https://reimbar.org/dev/nushell/
+    #   nushell.extraEnv = mkIf cfg.enableFishIntegration /*bash*/ ''
+    #     # $env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin') 
+    #     use std "path add"
+    #     path add /opt/homebrew/bin
+    #   '';
+    # };
 
     # nix-darwin homebrew module
     # Manages homebrew packages

--- a/modules/darwin/packages.nix
+++ b/modules/darwin/packages.nix
@@ -1,6 +1,11 @@
-{ pkgs, ... }:
-
+{ pkgs, variables, ... }:
+let
+  inherit (variables) userName;
+in
 {
   imports = [ ../shared/packages.nix ];
-  home.packages = with pkgs; [ dockutil ];
+
+  home-manager.users.${userName} = {
+    home.packages = with pkgs; [ dockutil ];
+  };
 }

--- a/modules/nixos/home-manager.nix
+++ b/modules/nixos/home-manager.nix
@@ -4,6 +4,8 @@ let
   inherit (variables) userName;
 in
 {
+  imports = [ ./packages.nix ];
+
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;
@@ -19,7 +21,6 @@ in
 
         imports = [
           ./files.nix
-          ./packages.nix
           ../shared/programs.nix
         ];
 

--- a/modules/nixos/packages.nix
+++ b/modules/nixos/packages.nix
@@ -1,67 +1,73 @@
-{ pkgs, ... }:
-{ 
- imports = [ ../shared/packages.nix ];
- home.packages = with pkgs; [
-  # Security and authentication
-  yubikey-agent
-  keepassxc
+{ pkgs, variables, ... }:
+let
+  inherit (variables) userName;
+in
+{
+  imports = [ ../shared/packages.nix ];
 
-  # App and package management
-  appimage-run
-  gnumake
-  cmake
-  home-manager
+  home-manager.users.${userName} = {
+    home.packages = with pkgs; [
+      # Security and authentication
+      yubikey-agent
+      keepassxc
 
-  # Media and design tools
-  vlc
-  fontconfig
-  font-manager
+      # App and package management
+      appimage-run
+      gnumake
+      cmake
+      home-manager
 
-  # Productivity tools
-  bc # old school calculator
-  galculator
+      # Media and design tools
+      vlc
+      fontconfig
+      font-manager
 
-  # Audio tools
-  cava # Terminal audio visualizer
-  pavucontrol # Pulse audio controls
+      # Productivity tools
+      bc # old school calculator
+      galculator
 
-  # Testing and development tools
-  direnv
-  rofi
-  rofi-calc
-  postgresql
-  libtool # for Emacs vterm
+      # Audio tools
+      cava # Terminal audio visualizer
+      pavucontrol # Pulse audio controls
 
-  # Screenshot and recording tools
-  flameshot
+      # Testing and development tools
+      direnv
+      rofi
+      rofi-calc
+      postgresql
+      libtool # for Emacs vterm
 
-  # Text and terminal utilities
-  feh # Manage wallpapers
-  screenkey
-  tree
-  unixtools.ifconfig
-  unixtools.netstat
-  xclip # For the org-download package in Emacs
-  xorg.xwininfo # Provides a cursor to click and learn about windows
-  xorg.xrandr
+      # Screenshot and recording tools
+      flameshot
 
-  # File and system utilities
-  inotify-tools # inotifywait, inotifywatch - For file system events
-  i3lock-fancy-rapid
-  libnotify
-  pcmanfm # File browser
-  sqlite
-  xdg-utils
+      # Text and terminal utilities
+      feh # Manage wallpapers
+      screenkey
+      tree
+      unixtools.ifconfig
+      unixtools.netstat
+      xclip # For the org-download package in Emacs
+      xorg.xwininfo # Provides a cursor to click and learn about windows
+      xorg.xrandr
 
-  # Other utilities
-  yad # yad-calendar is used with polybar
-  xdotool
-  google-chrome
+      # File and system utilities
+      inotify-tools # inotifywait, inotifywatch - For file system events
+      i3lock-fancy-rapid
+      libnotify
+      pcmanfm # File browser
+      sqlite
+      xdg-utils
 
-  # PDF viewer
-  zathura
+      # Other utilities
+      yad # yad-calendar is used with polybar
+      xdotool
+      google-chrome
 
-  # Music and entertainment
-  spotify
- ];
+      # PDF viewer
+      zathura
+
+      # Music and entertainment
+      spotify
+    ];
+  };
 }

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -1,51 +1,59 @@
-{ pkgs, ... }:
+{ pkgs, variables, ... }:
+let
+  inherit (variables) userName;
+in
 {
-  home.packages = with pkgs; [
-    # General packages for development and system management
-    alacritty
-    bash-completion
-    coreutils
-    fastfetch
-    openssh
-    wget
-
-    # Encryption and security tools
-    age
-    gnupg
-
-    # Media-related packages
-    # ffmpeg
-
-    # Fonts
-    font-awesome
-    hack-font
-    noto-fonts
-    noto-fonts-emoji
-    meslo-lgs-nf
-    jetbrains-mono
-    # (pkgs.nerdfonts.override { fonts = [ "Monaspace" ]; })
-
-    # Git
-    gh
-    graphite-cli
-
-    # Development tools
-    nodejs
-    nodePackages.npm
-    nodePackages.pnpm
-
-    cargo
-
-    # Nix Utils
-    nurl
-    nil
-    nixfmt-rfc-style
-    statix
-
-    # Text and terminal utilities
-    jq
-    ripgrep
-    lunarvim
-    neovim
+  fonts.packages = [
+    pkgs.nerd-fonts.monaspace
   ];
+
+  home-manager.users.${userName} = {
+    home.packages = with pkgs; [
+      # General packages for development and system management
+      alacritty
+      bash-completion
+      coreutils
+      fastfetch
+      openssh
+      wget
+
+      # Encryption and security tools
+      age
+      gnupg
+
+      # Media-related packages
+      # ffmpeg
+
+      # Fonts
+      font-awesome
+      hack-font
+      noto-fonts
+      noto-fonts-emoji
+      meslo-lgs-nf
+      jetbrains-mono
+
+      # Git
+      gh
+      graphite-cli
+
+      # Development tools
+      nodejs
+      nodePackages.npm
+      nodePackages.pnpm
+
+      cargo
+
+      # Nix Utils
+      nurl
+      nil
+      nixfmt-rfc-style
+      statix
+
+      # Text and terminal utilities
+      jq
+      ripgrep
+      lunarvim
+      neovim
+    ];
+  };
 }

--- a/modules/shared/packages.nix
+++ b/modules/shared/packages.nix
@@ -23,7 +23,7 @@
     noto-fonts-emoji
     meslo-lgs-nf
     jetbrains-mono
-    (pkgs.nerdfonts.override { fonts = [ "Monaspace" ]; })
+    # (pkgs.nerdfonts.override { fonts = [ "Monaspace" ]; })
 
     # Git
     gh

--- a/modules/shared/programs.nix
+++ b/modules/shared/programs.nix
@@ -94,6 +94,20 @@ in
           ];
         };
       };
+      keymap = {
+        manager.prepend_keymap = [
+          {
+            on = "<PageUp>";
+            run = "seek -1";
+            desc = "Scroll up in preview";
+          }
+          {
+            on = "<PageDown>";
+            run = "seek 1";
+            desc = "Scroll down in preview";
+          }
+        ];
+      };
     };
 
     ssh = {
@@ -554,7 +568,7 @@ in
           })
 
           config.max_fps = 120
-          
+
           -- Needed for Nix
           config.front_end = "WebGpu"
 

--- a/modules/shared/programs.nix
+++ b/modules/shared/programs.nix
@@ -1,4 +1,11 @@
-{ pkgs, lib, variables, inputs, osConfig, ... }:
+{
+  pkgs,
+  lib,
+  variables,
+  inputs,
+  osConfig,
+  ...
+}:
 
 let
   inherit (variables) userName fullName;
@@ -31,7 +38,7 @@ in
 
     # ---------------------
     # -- Shell utilities --
-    # --------------------- 
+    # ---------------------
     fd.enable = true;
     bat.enable = true;
 
@@ -47,9 +54,13 @@ in
       fileWidgetCommand = "fd --hidden --strip-cwd-prefix --exclude .git";
       fileWidgetOptions =
         if isFish then
-          [ "--preview 'if test -d {}; eza --tree --all --level=3 --color=always {} | head -200; else; bat -n --color=always --line-range :500 {}; end'" ]
+          [
+            "--preview 'if test -d {}; eza --tree --all --level=3 --color=always {} | head -200; else; bat -n --color=always --line-range :500 {}; end'"
+          ]
         else
-          [ "--preview 'if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'" ];
+          [
+            "--preview 'if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'"
+          ];
       changeDirWidgetCommand = "fd --type d --hidden --strip-cwd-prefix --exclude .git";
       changeDirWidgetOptions = [ "--preview 'eza --tree --color=always {} | head -200'" ];
     };
@@ -76,7 +87,11 @@ in
       settings = {
         manager = {
           show_hidden = true;
-          ratio = [ 1 3 4 ];
+          ratio = [
+            1
+            3
+            4
+          ];
         };
       };
     };
@@ -157,7 +172,7 @@ in
         signByDefault = true;
       };
       lfs.enable = true;
-      # setting `delta.enable = true;` sets 
+      # setting `delta.enable = true;` sets
       #   `core.pager = "delta"` and
       #   `interactive.diffFilter = "delta --color-only";`
       # by default, so they don't need to be set manually
@@ -465,23 +480,83 @@ in
           local wezterm = require("wezterm")
 
           local config = wezterm.config_builder()
+          local tabline = wezterm.plugin.require("https://github.com/michaelbrusegard/tabline.wez")
 
-          config.font = wezterm.font("MonaspiceKr Nerd Font")
+          -- config.font = wezterm.font("MonaspiceKr Nerd Font")
+          config.font = wezterm.font_with_fallback({ "MonaspiceKr Nerd Font", "Monaspace Krypton" })
+
           config.font_size = 13
           config.color_scheme = "Tokyo Night"
 
           config.default_cursor_style = "SteadyUnderline"
-          config.front_end = "WebGpu"
 
-          config.enable_tab_bar = false
-          config.window_decorations = "RESIZE | TITLE"
+          -- Window
+          config.window_decorations = "RESIZE"
+          -- config.window_decorations = "RESIZE | TITLE"
           config.window_background_opacity = 0.9
           config.macos_window_background_blur = 30
 
           config.command_palette_bg_color = "#1A1B26"
           config.command_palette_fg_color = "#C0CAF5"
 
+          -- Tab bar
+          --
+          -- This errors out, apply tab defaults manually
+          -- tabline.apply_to_config(config)
+          config.enable_tab_bar = true
+          config.use_fancy_tab_bar = false
+          config.show_tab_index_in_tab_bar = false
+          config.switch_to_last_active_tab_when_closing_tab = true
+
+          tabline.setup({
+            options = {
+              icons_enabled = true,
+              theme = "tokyonight_moon",
+              section_separators = {
+                left = "",
+                right = "", -- Removed all separators to reduce padding
+              },
+              component_separators = {
+                left = "",
+                right = "", -- Removed internal separators
+              },
+              tab_separators = {
+                left = "",
+                right = "", -- Made tab separators invisible to reduce spacing
+              },
+            },
+            sections = {
+              tabline_a = { "hostname", padding = 1 },
+              tabline_b = { "" },
+              tabline_c = { "" },
+              tab_active = {
+                { "index", padding = 1 },
+                -- { "parent", padding =
+                { "/", padding = 1 },
+                { "cwd", padding = 1 },
+                { "zoomed", padding = 1 },
+              },
+              tab_inactive = {
+                { "index", padding = 1 },
+                { "process", padding = 1 },
+              },
+              tabline_x = {
+                { "ram", padding = 1 },
+                { "cpu", padding = 1 },
+              },
+              tabline_y = {
+                { "datetime", padding = 1 },
+                { "battery", padding = 1 },
+              },
+              tabline_z = { "" },
+            },
+            extensions = {},
+          })
+
           config.max_fps = 120
+          
+          -- Needed for Nix
+          config.front_end = "WebGpu"
 
           return config
         '';


### PR DESCRIPTION
### This PR:
- Updates the flake.lock file with newer versions of dependencies
- Updates WezTerm configuration with tabline plugin and improved tab bar settings
- Disables custom homebrew shell integration options that are no longer needed
- Updates nerdfonts configuration to use system-wide fonts.packages instead of home.packages
- Modularizes package management by moving `packages.nix` imports to the module level and restructures package definitions to use home-manager.users.${userName} pattern


