### PR TITLE
chore: Update packages and refactor NixOS configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1723293904,
-        "narHash": "sha256-b+uqzj+Wa6xgMS9aNbX4I+sXeb5biPDi39VgvSFqFvU=",
+        "lastModified": 1736955230,
+        "narHash": "sha256-uenf8fv2eG5bKM8C/UvFaiJMZ4IpUFaQxk9OH5t/1gA=",
         "owner": "ryantm",
         "repo": "agenix",
-        "rev": "f6291c5935fdc4e0bef208cfc0dcab7e3f7a1c41",
+        "rev": "e600439ec4c273cf11e06fe4d9d906fb98fa097c",
         "type": "github"
       },
       "original": {
@@ -27,27 +27,27 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1731323744,
-        "narHash": "sha256-SxUQm4cTHcaoPQHoXe26ZV8cZiMWBGow8MjE4L+MckM=",
+        "lastModified": 1742457334,
+        "narHash": "sha256-Gn7ruyb3NDFr+SsHBfA2NsJI8YkkWdECqLRj/xcjt+E=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "254bf3fe9d8fa2e1b2fb55dbcf535b2d870180c4",
+        "rev": "f3bd91d3afe086824d24708230e1f0c7f943135a",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "4.4.5",
+        "ref": "4.4.25",
         "repo": "brew",
         "type": "github"
       }
     },
     "crane": {
       "locked": {
-        "lastModified": 1725409566,
-        "narHash": "sha256-PrtLmqhM6UtJP7v7IGyzjBFhbG4eOAHT6LPYOFmYfbk=",
+        "lastModified": 1741481578,
+        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "7e4586bad4e3f8f97a9271def747cf58c4b68f3c",
+        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737926801,
-        "narHash": "sha256-un7IETRNjUm83jM5Gd/7BO4rCzzkom46O0FDMo5toaI=",
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "62ba0a22426721c94e08f0779ed8235d5672869b",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737038063,
-        "narHash": "sha256-rMEuiK69MDhjz1JgbaeQ9mBDXMJ2/P8vmOYRbFndXsk=",
+        "lastModified": 1745369821,
+        "narHash": "sha256-mi6cAjuBztm9gFfpiVo6mAn81cCID6nmDXh5Kmyjwyc=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "bf0abfde48f469c256f2b0f481c6281ff04a5db2",
+        "rev": "c5140c6079ff690e85eac0b86e254de16a79a4b7",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737762889,
-        "narHash": "sha256-5HGG09bh/Yx0JA8wtBMAzt0HMCL1bYZ93x4IqzVExio=",
+        "lastModified": 1745380081,
+        "narHash": "sha256-bUy25YkdRfdWPxSyx22igWi6g3rd3HXKFg+yL4dfBPY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "daf04c5950b676f47a794300657f1d3d14c1a120",
+        "rev": "1d0e13904bd8c444ab1595f686ede5eff377e881",
         "type": "github"
       },
       "original": {
@@ -183,11 +183,11 @@
     "homebrew-bundle": {
       "flake": false,
       "locked": {
-        "lastModified": 1737709977,
-        "narHash": "sha256-DvsRUJfrkseHj8mYhh1Zc8EyGX31A4MV0o8Vjlx6egU=",
+        "lastModified": 1745335228,
+        "narHash": "sha256-TIKR2UgtyUmHLNZp255/vLs+1I10hXe+sciMEbAGFwE=",
         "owner": "homebrew",
         "repo": "homebrew-bundle",
-        "rev": "ef706d4b71a7a63ca6b50c5c2093e19594d2e024",
+        "rev": "a3265c84b232e13048ecbf6fc18a2eedfadbeb08",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1737939319,
-        "narHash": "sha256-8PrmGqIecs5BJMJVlKsIermgjLJT33sFHiVuaMoEVbw=",
+        "lastModified": 1745384785,
+        "narHash": "sha256-od7teyhD070wW8IGK9mFlMqnw/DlARS3ifi2nxM2vgM=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "70c09f341c55f28509013ab906334a0ed1e61304",
+        "rev": "eb3cb0059f4ba1d94fcbc510b34a40a6e84d13ee",
         "type": "github"
       },
       "original": {
@@ -215,11 +215,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1737938486,
-        "narHash": "sha256-kTqB0E8kHF/poopNLe/EMXQLatNWVkbMZnxn4HyLpJ0=",
+        "lastModified": 1745386937,
+        "narHash": "sha256-HqAw3lky78KKc0QK6UlZsoHuJEM2UX6zuDwl9TbltEs=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "2dee229e4cf1db732298fb4dae0550ae53958c25",
+        "rev": "46d01fba216c45e2c2ef71a75c7cab4366ce375b",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736041957,
-        "narHash": "sha256-Kk/cVtkxwfHNoB6nINUarMLTtyAEvH+ohzxKBptMzzg=",
+        "lastModified": 1744563914,
+        "narHash": "sha256-0exTKCXDE/8G7gZQ9Gk3EcZBAL7lwzxhD7DtUBsnlGI=",
         "owner": "zhaofengli-wip",
         "repo": "nix-homebrew",
-        "rev": "a6d99cc7436fc18c097b3536d9c45c0548c694c8",
+        "rev": "53507607d69c88efc816e806b8139607c7257285",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1737885589,
-        "narHash": "sha256-Zf0hSrtzaM1DEz8//+Xs51k/wdSajticVrATqDrfQjg=",
+        "lastModified": 1745234285,
+        "narHash": "sha256-GfpyMzxwkfgRVN0cTGQSkTC0OHhEkv3Jf6Tcjm//qZ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "852ff1d9e153d8875a83602e03fdef8a63f0ecf8",
+        "rev": "c11863f1e964833214b767f4a369c6e6a7aba141",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1726755133,
-        "narHash": "sha256-03XIEjHeZEjHXctsXYUB+ZLQmM0WuhR6qWQjwekFk/M=",
+        "lastModified": 1744897914,
+        "narHash": "sha256-GIVU92o2TZBnKQXTb76zpQbWR4zjU2rFqWKNIIpXnqA=",
         "owner": "yaxitech",
         "repo": "ragenix",
-        "rev": "687ee92114bce9c4724376cf6b21235abe880bfa",
+        "rev": "40f2e17ecaeab4d78ec323e96a04548c0aaa5223",
         "type": "github"
       },
       "original": {
@@ -343,11 +343,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725675754,
-        "narHash": "sha256-hXW3csqePOcF2e/PYnpXj72KEYyNj2HzTrVNmS/F7Ug=",
+        "lastModified": 1741400194,
+        "narHash": "sha256-tEpgT+q5KlGjHSm8MnINgTPErEl8YDzX3Eps8PVc09g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8cc45e678e914a16c8e224c3237fb07cf21e5e54",
+        "rev": "16b6045a232fea0e9e4c69e55a6e269607dd8e3f",
         "type": "github"
       },
       "original": {
@@ -392,11 +392,11 @@
         "tokyonight-rofi": "tokyonight-rofi"
       },
       "locked": {
-        "lastModified": 1721479101,
-        "narHash": "sha256-UHRSZ0j0LhTj7mp87A4gwVUM5h+B5Ak+L/hPpTZrNjw=",
+        "lastModified": 1744398025,
+        "narHash": "sha256-NhxZ0ZtNeupQ3/Rk3RQwRPgcSwGVExRR7mELFlRsq1U=",
         "owner": "mrjones2014",
         "repo": "tokyonight.nix",
-        "rev": "3d4d3d72e25ad40eb76b07d33f926c5dc745106c",
+        "rev": "c78baee8d8ef560fe81156b952c99b1f8e649a5b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,22 +54,39 @@
           darwin = "nixos-mac";
         };
       };
-      linuxSystems = [ "x86_64-linux" "aarch64-linux" ];
-      darwinSystems = [ "aarch64-darwin" "x86_64-darwin" ];
+      linuxSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      darwinSystems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
 
       forAllSystems = f: nixpkgs.lib.genAttrs (linuxSystems ++ darwinSystems) f;
       pkgsForSystem = system: import nixpkgs { inherit system; };
 
-      devShell = system: let pkgs = pkgsForSystem system; in {
-        default = with pkgs; mkShell {
-            nativeBuildInputs = with pkgs; [ bashInteractive git ];
-            shellHook = ''
-              export EDITOR=vim
-            '';
-          };
+      devShell =
+        system:
+        let
+          pkgs = pkgsForSystem system;
+        in
+        {
+          default =
+            with pkgs;
+            mkShell {
+              nativeBuildInputs = with pkgs; [
+                bashInteractive
+                git
+              ];
+              shellHook = ''
+                export EDITOR=nvim
+              '';
+            };
         };
 
-      mkApp = scriptName: system:
+      mkApp =
+        scriptName: system:
         let
           pkgs = pkgsForSystem system;
           scriptContent = builtins.readFile (./. + "/apps/${system}/${scriptName}");
@@ -101,8 +118,9 @@
       devShells = forAllSystems devShell;
       apps = forAllSystems mkAppsFromDir;
 
-      darwinConfigurations = nixpkgs.lib.genAttrs darwinSystems ( 
-        system: darwin.lib.darwinSystem {
+      darwinConfigurations = nixpkgs.lib.genAttrs darwinSystems (
+        system:
+        darwin.lib.darwinSystem {
           inherit system;
           specialArgs = { inherit variables inputs; };
           modules = [
@@ -116,16 +134,18 @@
 
       nixosConfigurations =
         let
-          mkNixos = host: system: nixpkgs.lib.nixosSystem {
-            inherit system;
-            specialArgs = { inherit variables inputs; };
-            modules = [
-              disko.nixosModules.disko
-              home-manager.nixosModules.home-manager
-              ragenix.nixosModules.default
-              ./hosts/${host}
-            ];
-          };
+          mkNixos =
+            host: system:
+            nixpkgs.lib.nixosSystem {
+              inherit system;
+              specialArgs = { inherit variables inputs; };
+              modules = [
+                disko.nixosModules.disko
+                home-manager.nixosModules.home-manager
+                ragenix.nixosModules.default
+                ./hosts/${host}
+              ];
+            };
         in
         {
           "nixos-x86_64" = mkNixos "nixos" "x86_64-linux";

--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -23,7 +23,10 @@ in
   };
 
   # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
+  # INFO:: nix-darwin now manages nix-daemon
+  # unconditionally when `nix.enable` is on.
+  # services.nix-daemon.enable = true;
+  # nix.enable = false;
 
   # Turn off NIX_PATH warnings now that we're using flakes
   system.checks.verifyNixPath = false;
@@ -35,7 +38,7 @@ in
 
   # MacOS settings
   system = {
-    stateVersion = 4;
+    stateVersion = 5;
 
     defaults = {
       NSGlobalDomain = {

--- a/hosts/nixos-common.nix
+++ b/hosts/nixos-common.nix
@@ -9,6 +9,10 @@ in
     ../modules/shared/cachix
     ../modules/shared
   ];
+
+  shells.zsh.enable = true;
+  shells.fish.enable = false;
+
   users.users.${userName} = {
     isNormalUser = true;
     extraGroups = [
@@ -18,11 +22,58 @@ in
     # openssh.authorizedKeys.keys = keys;
   };
 
+  programs = {
+    zsh.enable = true;
+    gnupg.agent.enable = true;
+
+    # Needed for anything GTK related
+    dconf.enable = true;
+  };
+
   # users.users.root = {
   #   openssh.authorizedKeys.keys = keys;
   # };
 
   time.timeZone = "America/New_York";
+
+  services = {
+    xserver = {
+      enable = true;
+      displayManager.gdm.enable = true;
+      desktopManager.gnome.enable = true;
+      xkb.layout = "us";
+      # xkbOptions = "ctrl:nocaps";
+
+      # Uncomment these for AMD or Nvidia GPU
+      # boot.initrd.kernelModules = [ "amdgpu" ];
+      # videoDrivers = [ "amdgpu" ];
+      # videoDrivers = [ "nvidia" ];
+
+      # Uncomment for Nvidia GPU
+      # This helps fix tearing of windows for Nvidia cards
+      # screenSection = ''
+      #   Option       "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
+      #   Option       "AllowIndirectGLXProtocol" "off"
+      #   Option       "TripleBuffer" "on"
+      # '';
+    };
+
+    # Better support for general peripherals
+    libinput.enable = true;
+
+    # Let's be able to SSH into this machine
+    openssh.enable = true;
+
+    # Enable CUPS to print documents
+    # printing.enable = true;
+    # printing.drivers = [ pkgs.brlaser ]; # Brother printer driver
+
+    gvfs.enable = true; # Mount, trash, and other functionalities
+    tumbler.enable = true; # Thumbnail support for images
+  };
+
+  # Sound working in utm vm without this
+  # sound.enable = true;
 
   # Use the systemd-boot EFI boot loader.
   boot = {
@@ -53,18 +104,25 @@ in
   # Video support
   hardware.graphics.enable = true;
   # hardware.pulseaudio.enable = true;
-  
+  # hardware.nvidia.modesetting.enable = true;
+
+  # Enable Xbox support
+  # hardware.xone.enable = true;
 
   # Don't require password for users in `wheel` group for these commands
   security.sudo = {
     enable = true;
-    extraRules = [{
-      commands = [{
-          command = "${pkgs.systemd}/bin/reboot";
-          options = [ "NOPASSWD" ];
-        }];
-      groups = [ "wheel" ];
-    }];
+    extraRules = [
+      {
+        commands = [
+          {
+            command = "${pkgs.systemd}/bin/reboot";
+            options = [ "NOPASSWD" ];
+          }
+        ];
+        groups = [ "wheel" ];
+      }
+    ];
   };
 
   # Add docker daemon
@@ -74,7 +132,6 @@ in
   #     logDriver = "json-file";
   #   };
   # };
-
 
   fonts.packages = with pkgs; [
     dejavu_fonts
@@ -86,10 +143,11 @@ in
     noto-fonts-emoji
   ];
 
-
   environment.systemPackages = with pkgs; [
     gitAndTools.gitFull
     inetutils
     gnome-tweaks
   ];
+
+  system.stateVersion = "21.05"; # Don't change this
 }

--- a/hosts/nixos/default.nix
+++ b/hosts/nixos/default.nix
@@ -8,72 +8,14 @@ in
     ../nixos-common.nix
   ];
 
-  shells.zsh.enable = true;
-  shells.fish.enable = false;
-
   # The global useDHCP flag is deprecated, therefore explicitly set to false here.
   # Per-interface useDHCP will be mandatory in the future, so this generated config
   # replicates the default behaviour.
-  # TODO: This should be in a system specific file
   networking = {
     inherit hostName;
     useDHCP = false;
     interfaces."%INTERFACE%".useDHCP = true;
   };
 
-  # Manages keys and such
-  programs = {
-    zsh.enable = true;
-    gnupg.agent.enable = true;
-
-    # Needed for anything GTK related
-    dconf.enable = true;
-  };
-
-  services = {
-    xserver = {
-      enable = true;
-      displayManager.gdm.enable = true;
-      desktopManager.gnome.enable = true;
-      xkb.layout = "us";
-      # xkbOptions = "ctrl:nocaps";
-
-      # Uncomment these for AMD or Nvidia GPU
-      # boot.initrd.kernelModules = [ "amdgpu" ];
-      # videoDrivers = [ "amdgpu" ];
-      # videoDrivers = [ "nvidia" ];
-
-      # Uncomment for Nvidia GPU
-      # This helps fix tearing of windows for Nvidia cards
-      # screenSection = ''
-      #   Option       "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
-      #   Option       "AllowIndirectGLXProtocol" "off"
-      #   Option       "TripleBuffer" "on"
-      # '';
-    };
-
-    # Better support for general peripherals
-    libinput.enable = true;
-
-    # Let's be able to SSH into this machine
-    openssh.enable = true;
-
-    # Enable CUPS to print documents
-    # printing.enable = true;
-    # printing.drivers = [ pkgs.brlaser ]; # Brother printer driver
-
-    gvfs.enable = true; # Mount, trash, and other functionalities
-    tumbler.enable = true; # Thumbnail support for images
-  };
-
-  # Enable sound
-  # sound.enable = true;
-
   # hardware.nvidia.modesetting.enable = true;
-
-  # Enable Xbox support
-  # hardware.xone.enable = true;
-
-
-  system.stateVersion = "21.05"; # Don't change this
 }

--- a/hosts/vm/default.nix
+++ b/hosts/vm/default.nix
@@ -8,61 +8,25 @@ in
     ../nixos-common.nix
   ];
 
-  shells.zsh.enable = true;
-  shells.fish.enable = false;
-
   # The global useDHCP flag is deprecated, therefore explicitly set to false here.
   # Per-interface useDHCP will be mandatory in the future, so this generated config
   # replicates the default behaviour.
-  # TODO: This should be in a system specific file
   networking = {
     inherit hostName;
     useDHCP = false;
     interfaces."%INTERFACE%".useDHCP = true;
   };
 
-  # Manages keys and such
-  programs = {
-    zsh.enable = true;
-    gnupg.agent.enable = true;
-
-    # Needed for anything GTK related
-    dconf.enable = true;
-  };
-
   services = {
     qemuGuest.enable = true;
     spice-vdagentd.enable = true;
     xserver = {
-      enable = true;
       videoDrivers = [ "qxl" ];
-      displayManager.gdm.enable = true;
-      desktopManager.gnome.enable = true;
-      xkb.layout = "us";
       # xkbOptions = "ctrl:nocaps";
     };
-    # Better support for general peripherals
-    libinput.enable = true;
-
-    # Let's be able to SSH into this machine
-    openssh.enable = true;
-
-    # Enable CUPS to print documents
-    # printing.enable = true;
-    # printing.drivers = [ pkgs.brlaser ]; # Brother printer driver
-
-    gvfs.enable = true; # Mount, trash, and other functionalities
-    tumbler.enable = true; # Thumbnail support for images
   };
-
-  # Sound working in utm vm without this
-  # sound.enable = true;
-
-  # hardware.nvidia.modesetting.enable = true;
 
   environment.systemPackages = with pkgs; [
     spice-vdagent
   ];
-
-  system.stateVersion = "21.05"; # Don't change this
 }

--- a/modules/darwin/homebrew.nix
+++ b/modules/darwin/homebrew.nix
@@ -1,4 +1,9 @@
-{ variables, inputs, config, ... }:
+{
+  variables,
+  inputs,
+  config,
+  ...
+}:
 let
   inherit (variables) userName;
   inherit (inputs) homebrew-bundle homebrew-core homebrew-cask;
@@ -47,7 +52,7 @@ in
 
     # Homebrew shell integration
     # home-manager.users.${userName}.programs = {
-    #   zsh.initExtra = mkIf cfg.enableZshIntegration /*bash*/ ''
+    #   zsh.initContent = mkIf cfg.enableZshIntegration /*bash*/ ''
     #     eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
     #   '';
     #
@@ -62,7 +67,7 @@ in
     #   # https://www.nushell.sh/book/configuration.html#homebrew
     #   # https://reimbar.org/dev/nushell/
     #   nushell.extraEnv = mkIf cfg.enableFishIntegration /*bash*/ ''
-    #     # $env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin') 
+    #     # $env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin')
     #     use std "path add"
     #     path add /opt/homebrew/bin
     #   '';
@@ -74,7 +79,7 @@ in
       enable = true;
       onActivation.cleanup = "uninstall";
 
-      # Fixes nix-darwin trying to untap nix-homebrew taps 
+      # Fixes nix-darwin trying to untap nix-homebrew taps
       # when onActivation.cleanup = uninstall/zap is set
       # https://github.com/zhaofengli/nix-homebrew/issues/5
       taps = builtins.attrNames config.nix-homebrew.taps;

--- a/modules/shared/nix.nix
+++ b/modules/shared/nix.nix
@@ -7,7 +7,10 @@ in
   nix = {
     package = pkgs.nix;
     settings.allowed-users = [ "${userName}" ];
-    settings.trusted-users = [ "@admin" "${userName}" ];
+    settings.trusted-users = [
+      "@admin"
+      "${userName}"
+    ];
 
     gc =
       {
@@ -50,7 +53,7 @@ in
       # ++ [(import (builtins.fetchTarball {
       #          url = "https://github.com/dustinlyons/emacs-overlay/archive/refs/heads/master.tar.gz";
       #          sha256 = "06413w510jmld20i4lik9b36cfafm501864yq8k4vxl5r4hn0j0h";
-      #      }))] 
+      #      }))]
     );
   };
 }

--- a/modules/shared/nix.nix
+++ b/modules/shared/nix.nix
@@ -15,7 +15,6 @@ in
         options = "--delete-older-than 30d";
       }
       // lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
-        user = "root";
         interval = { Weekday = 0; Hour = 2; Minute = 0; };
       }
       // lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {

--- a/modules/shared/shells/zsh.nix
+++ b/modules/shared/shells/zsh.nix
@@ -1,6 +1,17 @@
-{ pkgs, lib, config, variables, ... }:
+{
+  pkgs,
+  lib,
+  config,
+  variables,
+  ...
+}:
 let
-  inherit (lib) mkIf mkEnableOption mkMerge optionalAttrs;
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkMerge
+    optionalAttrs
+    ;
   inherit (variables) userName;
   zsh = config.shells.zsh;
 in
@@ -51,26 +62,6 @@ in
         lt3 = "eza --git --icons=always --color=always --long --no-filesize -all --tree --level=4";
         ltg = "eza --git --icons=always --color=always --long --no-filesize --tree --git-ignore";
       };
-      initExtra = /*bash*/ ''
-        # Advanced customization of fzf options via _fzf_comprun function
-        _fzf_comprun() {
-          local command=$1
-          shift
-
-          case "$command" in
-            cd)           fzf --preview 'eza --tree --color=always {} | head -200' "$@" ;;
-            export|unset) fzf --preview "eval 'echo $'{}"         "$@" ;;
-            ssh)          fzf --preview 'dig {}'                   "$@" ;;
-            *)            fzf --preview "bat -n --color=always --line-range :500 {}" "$@" ;;
-          esac
-        }
-
-
-        # -- fzf with bat and eza previews --
-        show_file_or_dir_preview='if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'
-        alias lspe="fzf --preview '$show_file_or_dir_preview'"
-        alias lsp="fd --max-depth 1 --hidden --follow --exclude .git | fzf --preview '$show_file_or_dir_preview'"
-      '';
       plugins = [
         {
           name = "fzf-git-sh";
@@ -78,20 +69,44 @@ in
           file = "share/fzf-git-sh/fzf-git.sh";
         }
       ];
-      initExtraFirst = /*bash*/ ''
-        if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
-          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
-        fi
+      initContent =
+        lib.mkOrder 500
+        /*bash*/ ''
+          if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
+            . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+            . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+          fi
 
-        # Define variables for directories
-        export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
-        export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
-        export PATH=$HOME/.local/share/bin:$PATH
+          # Define variables for directories
+          export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
+          export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
+          export PATH=$HOME/.local/share/bin:$PATH
 
-        # Remove history data we don't want to see
-        export HISTIGNORE="pwd:ls:cd"
-      '';
+          # Remove history data we don't want to see
+          export HISTIGNORE="pwd:ls:cd"
+        '' //
+
+        lib.mkOrder 1000
+          /*bash*/ ''
+            # Advanced customization of fzf options via _fzf_comprun function
+            _fzf_comprun() {
+              local command=$1
+              shift
+
+              case "$command" in
+                cd)           fzf --preview 'eza --tree --color=always {} | head -200' "$@" ;;
+                export|unset) fzf --preview "eval 'echo $'{}"         "$@" ;;
+                ssh)          fzf --preview 'dig {}'                   "$@" ;;
+                *)            fzf --preview "bat -n --color=always --line-range :500 {}" "$@" ;;
+              esac
+            }
+
+
+            # -- fzf with bat and eza previews --
+            show_file_or_dir_preview='if [ -d {} ]; then eza --tree --all --level=3 --color=always {} | head -200; else bat -n --color=always --line-range :500 {}; fi'
+            alias lspe="fzf --preview '$show_file_or_dir_preview'"
+            alias lsp="fd --max-depth 1 --hidden --follow --exclude .git | fzf --preview '$show_file_or_dir_preview'"
+          '';
     };
 
     # Set nix managed system shell

--- a/modules/shared/shells/zsh.nix
+++ b/modules/shared/shells/zsh.nix
@@ -40,7 +40,6 @@ in
       enable = true;
       autocd = false;
       autosuggestion.enable = true;
-      syntaxHighlighting.enable = true;
       enableCompletion = true;
       shellAliases = {
         # General aliases
@@ -68,26 +67,32 @@ in
           src = pkgs.fzf-git-sh;
           file = "share/fzf-git-sh/fzf-git.sh";
         }
+        {
+          name = "fast-syntax-highlighting";
+          src = pkgs.zsh-fast-syntax-highlighting;
+          file = "share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh";
+        }
       ];
       initContent =
         lib.mkOrder 500
-        /*bash*/ ''
-          if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
-            . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-            . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
-          fi
+          # bash
+          ''
+            if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
+              . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+              . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+            fi
 
-          # Define variables for directories
-          export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
-          export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
-          export PATH=$HOME/.local/share/bin:$PATH
+            # Define variables for directories
+            export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
+            export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
+            export PATH=$HOME/.local/share/bin:$PATH
 
-          # Remove history data we don't want to see
-          export HISTIGNORE="pwd:ls:cd"
-        '' //
-
-        lib.mkOrder 1000
-          /*bash*/ ''
+            # Remove history data we don't want to see
+            export HISTIGNORE="pwd:ls:cd"
+          ''
+        // lib.mkOrder 1000
+          # bash
+          ''
             # Advanced customization of fzf options via _fzf_comprun function
             _fzf_comprun() {
               local command=$1


### PR DESCRIPTION
This PR updates all packages in the flake.lock file and refactors the host configuration structure to reduce duplication.

Key changes:
- Moved common NixOS configuration from individual host files to the shared `nixos-common.nix` file
- Updated Darwin's stateVersion from 4 to 5
- Removed redundant `services.nix-daemon.enable` setting in Darwin config
- Changed default editor from `vim` to `nvim` in devShell
- Updated ZSH configuration to use `initContent` with ordered sections instead of `initExtra`
- Added fast-syntax-highlighting plugin for ZSH
- Improved formatting throughout the codebase

This simplifies the host configuration by treating them as system-specific files rather than generic templates, reducing unnecessary complexity.