### PR TITLE
refactor: Update README and improve modularity

### DIFF
--- a/hosts/darwin/default.nix
+++ b/hosts/darwin/default.nix
@@ -7,8 +7,9 @@ let
 in
 {
   imports = [
-    ../../modules/darwin/home-manager.nix
+    ../../modules/darwin/dock
     ../../modules/darwin/homebrew.nix
+    ../../modules/darwin/home-manager.nix
     ../../modules/shared/cachix
     ../../modules/shared
   ];

--- a/modules/darwin/home-manager.nix
+++ b/modules/darwin/home-manager.nix
@@ -4,11 +4,6 @@ let
   inherit (variables) userName;
 in
 {
-  imports = [ 
-    ./dock
-    ./packages.nix
-  ];
-
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;

--- a/modules/nixos/home-manager.nix
+++ b/modules/nixos/home-manager.nix
@@ -4,8 +4,6 @@ let
   inherit (variables) userName;
 in
 {
-  imports = [ ./packages.nix ];
-
   home-manager = {
     extraSpecialArgs = { inherit variables inputs; };
     useGlobalPkgs = true;

--- a/modules/shared/README.md
+++ b/modules/shared/README.md
@@ -6,11 +6,16 @@ This configuration gets imported by both modules. Some configuration examples in
 ## Layout
 ```
 .
-├── config             # Config files not written in Nix
-├── cachix             # Defines cachix, a global cache for builds
-├── default.nix        # Defines how we import overlays 
-├── files.nix          # Non-Nix, static configuration files (now immutable!)
-├── home-manager.nix   # The goods; most all shared config lives here
-├── packages.nix       # List of packages to share
+├── config/            # Config files not written in Nix
+├── shells/            # System and user shell configuration
+├── cachix/            # Defines cachix, a global cache for builds
+├── default.nix        # Imports all shared modules, imported by hosts
+├── nix.nix            # Shared Nix configuration
+├── options.nix        # Custom config options, like choosing a shell
+├── secrets.nix        # Agenix secrets configuration
+├── files.nix          # Symlinks for non-nix config files
+├── programs.nix       # Shared user config, imported by OS-specific home-manager modules
+├── packages.nix       # Shared system and user packages
+└── README.md          # This file
 
 ```

--- a/modules/shared/default.nix
+++ b/modules/shared/default.nix
@@ -4,6 +4,7 @@
   imports = [
     ./nix.nix
     ./options.nix
+    ./packages.nix
     ./secrets.nix
     ./shells/zsh.nix
     ./shells/fish.nix


### PR DESCRIPTION
This PR reorganizes how packages are imported by moving the `packages.nix` import from OS-specific home-manager modules to the `shared/default.nix` file. This ensures consistent package loading across all systems.

This PR also updates the README to better reflect the current directory structure
